### PR TITLE
add TypeScript type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'hyperapp-redux-devtools';


### PR DESCRIPTION
When compiling a TypeScript file with `hyperapp-redux-devtools`, we get the following error.

```
🚨  /Users/yuji/Dropbox/Projects/calculator/src/index.tsx(2,22)
Could not find a declaration file for module 'hyperapp-redux-devtools'. './node_modules/hyperapp-redux-devtools/index.js' implicitly has an 'any' type.  Try `npm install @types/hyperapp-redux-devtools` if it exists or add a new declaration (.d.ts) file containing `declare module 'hyperapp-redux-devtools';`
    1 | import { app, h, ActionsType, View } from "hyperapp";
  > 2 | import devtools from "hyperapp-redux-devtools";
      |                      ^^^^^^^^^^^^^^^^^^^^^^^^^
```

I added a very simple `index.d.ts` just having a module definition which fixed the above problem.

Thanks! (I can't live without this tool now.)